### PR TITLE
linux-aarch64 build for pysvg-py3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256:  a1183aa5d89871298c11f25d28640edc3798b6ed1e2b2a95c30d35985d6431d0
 
 build:
-  number: 7
+  number: 8
   skip: true  # [py27]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 


### PR DESCRIPTION
![pysvg-py3](https://github.com/user-attachments/assets/f6f6e725-a83a-4918-965e-e4d447cc35c1)
